### PR TITLE
Skip mobius

### DIFF
--- a/app/models/schedule2_model.py
+++ b/app/models/schedule2_model.py
@@ -200,9 +200,7 @@ class Schedule2(db.Model):
     @schedule_require_active
     def transition_to_chomp_queue(self):
         """ transition schedule state from unpublished to chomp queue """
-        self.promote_to_published()
-        return
-
+        
         if self.state not in ["unpublished", "chomp-processing"]:
             raise Exception(
                 "Schedule is in incorrect state for being added to chomp queue")
@@ -300,6 +298,9 @@ class Schedule2(db.Model):
     @schedule_require_active
     def transition_to_mobius_queue(self):
         """ transition to queue for mobius processing """
+        self.promote_to_published()
+        return
+
 
         if self.state not in ["unpublished", "mobius-processing"]:
             raise Exception(
@@ -340,7 +341,7 @@ class Schedule2(db.Model):
     def transition_to_published(self):
         """ publish a schedule """
 
-        if self.state not in ["unpublished", "mobius-processing"]:
+        if self.state not in ["unpublished", "mobius-processing", "mobius-queue"]:
             raise Exception(
                 "Schedule is in incorrect state for being published")
 


### PR DESCRIPTION
Makes the following changes:

1) Allows Chomp to work (which will require an additional microservice - otherwise the schedules will get stuck in the chomp-queue phase)

2) Skip mobius-queue and promote to published