### PR TITLE
Remove email on clockout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ app/static/stylesheets/*
 docker-compose.yml
 
 env.list
+.vscode

--- a/app/apiv2/marshal.py
+++ b/app/apiv2/marshal.py
@@ -232,6 +232,7 @@ timeclock_fields = {
     "start": fields.DateTime(dt_format="iso8601"),
     "stop": fields.DateTime(dt_format="iso8601"),
     "comment": fields.String,
+    "notify": fields.Boolean,
 }
 
 time_off_request_fields = {


### PR DESCRIPTION
Hitting the clock out endpoint would trigger an email saying your manager had clocked you out. Now you can send an additional "notify=false" parameter to not receive one.